### PR TITLE
Adds an 'active' stat.

### DIFF
--- a/src/components/region-stats.tsx
+++ b/src/components/region-stats.tsx
@@ -44,8 +44,8 @@ export class RegionStats extends Component<Props, State> {
         if (row.hidden) {
             return '';
         }
-        const {confirmed, recovered, deaths} = row.currentTotals;
-        const {deathsPercentage, recoveredPercentage} = row.percentages;
+        const {confirmed, recovered, deaths, active} = row.currentTotals;
+        const {deathsPercentage, recoveredPercentage, activePercentage} = row.percentages;
         const {newCasesAllTime, newCases7d} = row.averages;
         return (
             <div className='bb b--white-30 pb3 mb3'>
@@ -61,8 +61,17 @@ export class RegionStats extends Component<Props, State> {
                                 <div className='flex items-center'>
                                     <div style={{width: '37%'}} className='white-90'>Confirmed:</div>
                                     <div className='nowrap' style={{width: '63%'}}>
-                                        <div className='dib pa1 b bg-orange' style={{width: '100%'}}>
+                                        <div className='dib pa1 b bg-blue' style={{width: '100%'}}>
                                             {formatNumber(confirmed)}
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div className='flex items-center'>
+                                    <div style={{width: '37%'}} className='white-90'>Active:</div>
+                                    <div className='nowrap' style={{width: '63%'}}>
+                                        <div className='dib pa1 b bg-orange' style={{width: activePercentage + '%'}}>
+                                            {formatNumber(active)}
                                         </div>
                                     </div>
                                 </div>

--- a/src/components/time-series.tsx
+++ b/src/components/time-series.tsx
@@ -8,7 +8,8 @@ interface Props {
     totals: {
         confirmed: Array<number>,
         recovered: Array<number>,
-        deaths: Array<number>
+        deaths: Array<number>,
+        active: Array<number>
     },
     maxes: {
         confirmed: number,
@@ -51,9 +52,10 @@ export class TimeSeriesBars extends Component<Props, State> {
     }
 
     render() {
-        const {confirmed, recovered, deaths} = this.props.totals;
+        const {active, confirmed, recovered, deaths} = this.props.totals;
         const totals = confirmed.map((n, idx) => n + recovered[idx] + deaths[idx]);
-        const max = totals.reduce((max, n) => max > n ? max : n, 0);
+        const max = this.props.maxes.confirmed;
+        const activePerc = active.slice(-50).map(n => Math.round(n * 100 / max));
         const confirmedPerc = confirmed.slice(-50).map(n => Math.round(n * 100 / max));
         const recoveredPerc = recovered.slice(-50).map(n => Math.round(n * 100 / max));
         const deathsPerc = deaths.slice(-50).map(n => Math.round(n * 100 / max));
@@ -63,11 +65,11 @@ export class TimeSeriesBars extends Component<Props, State> {
         return (
             <div className='w-100'>
                 <div className='white-80 mb1'>
-                    <div className='pr4 f6'>Y-axis: cases (<span className='orange b'>confirmed</span>, <span className='green b'>recovered</span>, and <span className='gray b'>deaths</span> from 0 to {formatNumber(max)})</div>
+                    <div className='pr4 f6'>Y-axis: cases (<span className='orange b'>active</span>, <span className='green b'>recovered</span>, and <span className='gray b'>deaths</span> from 0 to {formatNumber(max)})</div>
                 </div>
 
                 <div className='flex w-100 items-end bg-dark-gray' style={{height: '100px'}}>
-                    {confirmedPerc.map((perc, idx) => this.vertBar(perc, idx, recoveredPerc, deathsPerc))}
+                    {activePerc.map((perc, idx) => this.vertBar(perc, idx, recoveredPerc, deathsPerc))}
                 </div>
 
                 <div className='white-80 mt1'>

--- a/src/utils/normalize-data.ts
+++ b/src/utils/normalize-data.ts
@@ -44,7 +44,6 @@ export function normalizeData(sourceData) {
     for (const key in agg) {
         rows.push(agg[key]);
     }
-    console.log(rows);
     // Additional pre-computation
     getActives(rows);
     getAverages(rows);


### PR DESCRIPTION
(addresses #17)

Tweaks a few things.
1. Adds an "active" stat to the normalized data. This, on each array entry, = confirmed - deaths - recovered.
2. Also adds an "activePercentage"
3. Modifies the view so that Confirmed remains (it's probably helpful to have the overall number) with a different color. Now there's a row for Active, and instead of "confirmed" in the bar chart, it's now the active value.

Since the total is (presumed to be...) active + recovered + deaths, that becomes the new y-max on the time series.
![Screen Shot 2020-03-19 at 3 12 58 PM](https://user-images.githubusercontent.com/2152243/77119696-34faa680-69f4-11ea-8e1a-055f1061e5cf.png)
