### PR TITLE
tweak colors for colorblindness

### DIFF
--- a/src/components/region-stats.tsx
+++ b/src/components/region-stats.tsx
@@ -60,8 +60,8 @@ export class RegionStats extends Component<Props, State> {
                             <div className='w-100 w-100-m w-50-ns pr2' style={{minWidth: '15rem'}}>
                                 <div className='flex items-center'>
                                     <div style={{width: '37%'}} className='white-90'>Confirmed:</div>
-                                    <div className='nowrap' style={{width: '63%'}}>
-                                        <div className='dib pa1 b bg-blue' style={{width: '100%'}}>
+                                    <div className='nowrap black-90' style={{width: '63%'}}>
+                                        <div className='dib pa1 b bg-white-90' style={{width: '100%'}}>
                                             {formatNumber(confirmed)}
                                         </div>
                                     </div>
@@ -81,7 +81,7 @@ export class RegionStats extends Component<Props, State> {
                                 <div className='flex items-center'>
                                     <div style={{width: '37%'}} className='white-90'>Recovered:</div>
                                     <div className='nowrap' style={{width: '63%'}}>
-                                        <div className='dib b bg-dark-green' style={{width: recoveredPercentage + '%'}}>
+                                        <div className='dib b bg-dark-blue' style={{width: recoveredPercentage + '%'}}>
                                             <div className='dib pa1'>
                                                 {formatNumber(recovered)} <span className='f6 white-80'>({recoveredPercentage + '%'})</span>
                                             </div>

--- a/src/components/region-stats.tsx
+++ b/src/components/region-stats.tsx
@@ -70,7 +70,7 @@ export class RegionStats extends Component<Props, State> {
                                 <div className='flex items-center'>
                                     <div style={{width: '37%'}} className='white-90'>Active:</div>
                                     <div className='nowrap' style={{width: '63%'}}>
-                                        <div className='dib pa1 b bg-orange' style={{width: activePercentage + '%'}}>
+                                        <div className='dib b bg-orange' style={{width: activePercentage + '%'}}>
                                             <div className='dib pa1'>
                                                 {formatNumber(active)} <span className='f6 white-80'>({activePercentage + '%'})</span>
                                             </div>

--- a/src/components/time-series.tsx
+++ b/src/components/time-series.tsx
@@ -45,7 +45,7 @@ export class TimeSeriesBars extends Component<Props, State> {
         return (
             <div class='flex flex-column h-100 justify-end' style={{width: '1.5%', margin: '0px 0.25%'}}>
                 <div title={deaths + '%'} className='bg-gray' style={{height: deaths + '%'}}></div>
-                <div title={recovered + '%'} className='bg-green' style={{height: recovered + '%'}}></div>
+                <div title={recovered + '%'} className='bg-dark-blue' style={{height: recovered + '%'}}></div>
                 <div title={confirmed + '%'} className='bg-orange' style={{height: confirmed + '%'}}></div>
             </div>
         );
@@ -65,7 +65,7 @@ export class TimeSeriesBars extends Component<Props, State> {
         return (
             <div className='w-100'>
                 <div className='white-80 mb1'>
-                    <div className='pr4 f6'>Y-axis: cases (<span className='orange b'>active</span>, <span className='green b'>recovered</span>, and <span className='gray b'>deaths</span> from 0 to {formatNumber(max)})</div>
+                    <div className='pr4 f6'>Y-axis: cases (<span className='orange b'>active</span>, <span className='dark-blue b'>recovered</span>, and <span className='gray b'>deaths</span> from 0 to {formatNumber(max)})</div>
                 </div>
 
                 <div className='flex w-100 items-end bg-dark-gray' style={{height: '100px'}}>


### PR DESCRIPTION
Change the green (recovered) -> blue, change the blue in the "confirmed" number to white (with black text).

I'm leaving the orange as-is for now. It seems ok, another option would be yellow (with black text). What do you think? is orange too red-adjacent?