### PR TITLE
Aggregate rows into additonal entries for worldwide and countries split into provinces

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,6 +1,6 @@
 import {h, Component, Fragment} from 'preact';
 import {fetchData} from '../utils/fetch-data';
-import {normalizeData} from '../utils/normalize-data';
+import {transformData} from '../utils/transform-data';
 import {sortByTotalConfirmed, sortByGrowth} from '../utils/sort-data';
 import {filterByCountry, filterByProvince} from '../utils/filter-data';
 import * as dataSources from '../constants/data-sources.json';
@@ -40,7 +40,7 @@ export class App extends Component<Props, State> {
 
     componentDidMount() {
         fetchData()
-            .then(normalizeData)
+            .then(transformData)
             .then((sourceData) => {
                 this.sourceData = sourceData;
                 this.applyFiltersAndSorts();
@@ -100,12 +100,12 @@ export class App extends Component<Props, State> {
                 <div className='mw8 center pa2 sans-serif white'>
                     <h1 className='light-gray tc f4 f2-m f2-ns'>COVID-19 Worldwide Growth</h1>
                     <p className='f6'>
-                        Data is updated daily from the
-                        <a href={dataSources.sourceURL} target='_blank' className='light-blue dib ml1'>
+                        Data is updated daily from the{' '}
+                        <a href={dataSources.sourceURL} target='_blank' className='light-blue'>
                             Johns Hopkins University CSSE COVID-10 Data Repository
                         </a>.
-                        Last update was {formatUTCDate()}.
-                        <a href={dataSources.citationsURL} target='_blank' className='light-blue dib ml1'>
+                        Last update was {formatUTCDate()} at 12am UTC.{' '}
+                        <a href={dataSources.citationsURL} target='_blank' className='light-blue'>
                             Disclaimer and citations
                         </a>.
                     </p>

--- a/src/components/region-stats.tsx
+++ b/src/components/region-stats.tsx
@@ -115,7 +115,7 @@ export class RegionStats extends Component<Props, State> {
                         </div>
                     </div>
                     <div className='w-100 w-100-m mt3 mt3-m mt0-ns w-50-ns flex'>
-                        <TimeSeriesBars dates={this.props.dates} totals={row.totals} maxes={row.maxes} />
+                        <TimeSeriesBars dates={this.props.dates} cases={row.cases} maxes={row.maxes} />
                     </div>
                 </div>
             </div>

--- a/src/components/time-series.tsx
+++ b/src/components/time-series.tsx
@@ -5,7 +5,7 @@ import {formatUTCDate, formatNumber} from '../utils/formatting';
 
 interface Props {
     dates: Array<Array<number>>;
-    totals: {
+    cases: {
         confirmed: Array<number>,
         recovered: Array<number>,
         deaths: Array<number>,
@@ -52,7 +52,7 @@ export class TimeSeriesBars extends Component<Props, State> {
     }
 
     render() {
-        const {active, confirmed, recovered, deaths} = this.props.totals;
+        const {active, confirmed, recovered, deaths} = this.props.cases;
         const max = this.props.maxes.confirmed;
         const activePerc = active.slice(-50).map(n => Math.round(n * 100 / max));
         const recoveredPerc = recovered.slice(-50).map(n => Math.round(n * 100 / max));
@@ -63,7 +63,7 @@ export class TimeSeriesBars extends Component<Props, State> {
         return (
             <div className='w-100'>
                 <div className='white-80 mb1'>
-                    <div className='pr4 f6'>Y-axis: cases (<span className='orange b'>active</span>, <span className='blue b'>recovered</span>, and <span className='gray b'>deaths</span> from 0 to {formatNumber(max)})</div>
+                    <div className='pr4 f6'>Y-axis: cases (<span className='orange b'>active</span>, <span className='blue b'>recovered</span>, and <span className='gray b'>deaths</span> up to <span className='b'>{formatNumber(max)}</span> cases)</div>
                 </div>
 
                 <div className='flex w-100 items-end bg-dark-gray' style={{height: '100px'}}>

--- a/src/utils/sort-data.ts
+++ b/src/utils/sort-data.ts
@@ -6,7 +6,7 @@
 // Sort all entries by the current total confirmed cases
 // Data is sorted in place without cloning
 export function sortByTotalConfirmed(rows, dir='desc') {
-    genericSort(rows, row => row.totals.confirmed[row.totals.confirmed.length - 1]);
+    genericSort(rows, row => row.cases.confirmed[row.cases.confirmed.length - 1]);
 }
 
 // Sort by the recent growth rate over last 7 days


### PR DESCRIPTION
@briehl I will merge this immediately because I want to share it, but if you have feedback please still post. We can always keep updating

Misc changes not mentioned in the title:
* renamed normalize-data to transform-data
* renamed row.totals to row.cases
* split out the calculation of row.currentTotals from the base transformData function into a separate function. This way it can run after we insert additional rows for worldwide/countries