### PR TITLE
Fix data for recent JHU updates :(

### DIFF
--- a/src/components/region-stats.tsx
+++ b/src/components/region-stats.tsx
@@ -17,11 +17,11 @@ interface State {
 
 // Purposes of these sections:
 // - show current state
-//   - show total cases, deaths, recovered
+//   - show total cases, deaths
 //   - compare the above values (bars)
 // - show growth rate
 //    - average new cases all time
-//    - average new cases this week
+//    - average new recent cases
 //    - horizontal bar chart over time of total cases
 
 
@@ -44,9 +44,9 @@ export class RegionStats extends Component<Props, State> {
         if (row.hidden) {
             return '';
         }
-        const {confirmed, recovered, deaths, active} = row.currentTotals;
-        const {deathsPercentage, recoveredPercentage, activePercentage} = row.percentages;
-        const {newCasesAllTime, newCases7d} = row.averages;
+        const {confirmed, deaths} = row.currentTotals;
+        const {deathsPercentage, activePercentage} = row.percentages;
+        const {newCasesAllTime, newCases7d, newCases3d} = row.averages;
         return (
             <div className='bb b--white-30 pb3 mb3'>
                 <div className='w-100 flex flex-wrap'>
@@ -60,31 +60,9 @@ export class RegionStats extends Component<Props, State> {
                             <div className='w-100 w-100-m w-50-ns pr2' style={{minWidth: '15rem'}}>
                                 <div className='flex items-center'>
                                     <div style={{width: '37%'}} className='white-90'>Confirmed:</div>
-                                    <div className='nowrap black-90' style={{width: '63%'}}>
-                                        <div className='dib pa1 b bg-white-80' style={{width: '100%'}}>
+                                    <div className='nowrap' style={{width: '63%'}}>
+                                        <div className='dib pa1 b bg-dark-blue' style={{width: '100%'}}>
                                             {formatNumber(confirmed)}
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div className='flex items-center'>
-                                    <div style={{width: '37%'}} className='white-90'>Active:</div>
-                                    <div className='nowrap' style={{width: '63%'}}>
-                                        <div className='dib b bg-orange' style={{width: activePercentage + '%'}}>
-                                            <div className='dib pa1'>
-                                                {formatNumber(active)} <span className='f6 white-80'>({activePercentage + '%'})</span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-
-                                <div className='flex items-center'>
-                                    <div style={{width: '37%'}} className='white-90'>Recovered:</div>
-                                    <div className='nowrap' style={{width: '63%'}}>
-                                        <div className='dib b bg-dark-blue' style={{width: recoveredPercentage + '%'}}>
-                                            <div className='dib pa1'>
-                                                {formatNumber(recovered)} <span className='f6 white-80'>({recoveredPercentage + '%'})</span>
-                                            </div>
                                         </div>
                                     </div>
                                 </div>
@@ -110,6 +88,10 @@ export class RegionStats extends Component<Props, State> {
                                 <div className='flex items-center pv1'>
                                     <div className='white-80' style={{width: '45%'}}>Last 7 days:</div>
                                     <div>{formatNumber(newCases7d)}</div>
+                                </div>
+                                <div className='flex items-center pv1'>
+                                    <div className='white-80' style={{width: '45%'}}>Last 3 days:</div>
+                                    <div>{formatNumber(newCases3d)}</div>
                                 </div>
                             </div>
                         </div>

--- a/src/components/time-series.tsx
+++ b/src/components/time-series.tsx
@@ -7,13 +7,10 @@ interface Props {
     dates: Array<Array<number>>;
     cases: {
         confirmed: Array<number>,
-        recovered: Array<number>,
         deaths: Array<number>,
-        active: Array<number>
     },
     maxes: {
         confirmed: number,
-        recovered: number,
         deaths: number
     }
 }
@@ -23,7 +20,7 @@ interface State {
 
 // Purposes of these sections:
 // - show current state
-//   - show total cases, deaths, recovered
+//   - show total cases, deaths
 //   - compare the above values (bars)
 // - show growth rate
 //    - average new cases all time
@@ -39,35 +36,29 @@ export class TimeSeriesBars extends Component<Props, State> {
         }
     }
 
-    vertBar(active, idx, recoveredPercentages, deathsPercentages) {
-        const recovered = recoveredPercentages[idx];
-        const deaths = deathsPercentages[idx];
+    vertBar(confirmed, idx, max) {
+        const perc = Math.round(confirmed * 100 / max);
         return (
             <div class='flex flex-column h-100 justify-end' style={{width: '1.5%', margin: '0px 0.25%'}}>
-                <div title={'Deaths: ' + deaths + '%'} className='bg-gray' style={{height: deaths + '%'}}></div>
-                <div title={'Recovered: ' + recovered + '%'} className='bg-blue' style={{height: recovered + '%'}}></div>
-                <div title={'Active: ' + active + '%'} className='bg-orange' style={{height: active + '%'}}></div>
+                <div title={'Confirmed: ' + perc + '%'} className='bg-blue' style={{height: perc + '%'}}></div>
             </div>
         );
     }
 
     render() {
-        const {active, confirmed, recovered, deaths} = this.props.cases;
+        const {confirmed, deaths} = this.props.cases;
         const max = this.props.maxes.confirmed;
-        const activePerc = active.slice(-50).map(n => Math.round(n * 100 / max));
-        const recoveredPerc = recovered.slice(-50).map(n => Math.round(n * 100 / max));
-        const deathsPerc = deaths.slice(-50).map(n => Math.round(n * 100 / max));
         const dates = this.props.dates.slice(-50);
         const startDate = formatUTCDate(dates[0]);
         const endDate = formatUTCDate(dates[dates.length - 1]);
         return (
             <div className='w-100'>
                 <div className='white-80 mb1'>
-                    <div className='pr4 f6'>Y-axis: cases (<span className='orange b'>active</span>, <span className='blue b'>recovered</span>, and <span className='gray b'>deaths</span> up to <span className='b'>{formatNumber(max)}</span> cases)</div>
+                    <div className='pr4 f6'>Y-axis: <span className='b blue'>confirmed</span> cases up to <span className='b'>{formatNumber(max)</span> total)</div>
                 </div>
 
                 <div className='flex w-100 items-end bg-dark-gray' style={{height: '100px'}}>
-                    {activePerc.map((perc, idx) => this.vertBar(perc, idx, recoveredPerc, deathsPerc))}
+                    {confirmed.map((n, idx) => this.vertBar(n, idx, max))}
                 </div>
 
                 <div className='white-80 mt1'>

--- a/src/constants/data-sources.json
+++ b/src/constants/data-sources.json
@@ -1,9 +1,8 @@
 {
     "sourceURL": "https://github.com/CSSEGISandData/COVID-19",
     "citationsURL": "https://github.com/jayrbolton/covid19-growth-dashboard/blob/master/disclaimer-citations.md",
-    "confirmed": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Confirmed.csv",
-    "deaths": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Deaths.csv",
-    "recovered": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Recovered.csv",
+    "deaths": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_global.csv",
+    "confirmed": "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv",
     "delimiter": ",",
     "dateRegex": "(\\d+)\\/(\\d+)\\/(\\d+)",
     "provinceIdx": 0,
@@ -11,5 +10,5 @@
     "latIdx": 2,
     "lngIdx": 3,
     "seriesIdx": 4,
-    "categoryKeys": ["confirmed", "deaths", "recovered"]
+    "categoryKeys": ["confirmed", "deaths"]
 }

--- a/src/utils/aggregate-data.ts
+++ b/src/utils/aggregate-data.ts
@@ -1,5 +1,0 @@
-/*
- * Data aggregation functions
- */
-
-

--- a/src/utils/fetch-data.ts
+++ b/src/utils/fetch-data.ts
@@ -5,41 +5,8 @@
 
 import * as dataSources from '~constants/data-sources.json';
 
-const LS_DATE_KEY = 'lastFetched';
-const LS_CACHE_PREFIX = 'cache_';
-const LS_CONFIRMED_KEY = 'cachedConfirmed';
-const LS_DEATHS_KEY = 'cachedDeaths';
-const LS_RECOVERED_KEY = 'cachedRecovered';
-
 
 export async function fetchData() {
-    // First try to fetch the date from a localStorage cache
-    // const lastFetch = window.localStorage.getItem(LS_DATE_KEY);
-    // const date = new Date();
-    // const today = `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
-    // if (lastFetch) {
-    //     if (lastFetch === today) {
-    //         // Fetch the date from the cache
-    //         const ret = {};
-    //         let validCache = true;
-    //         for (const key of dataSources.categoryKeys) {
-    //             ret[key] = localStorage.getItem(LS_CACHE_PREFIX + key);
-    //             if (!ret[key]) {
-    //                 validCache = false;
-    //                 break;
-    //             }
-    //         }
-    //         if (validCache) {
-    //             return ret;
-    //         } else {
-    //             clearCache();
-    //         }
-    //     } else {
-    //         clearCache();
-    //     }
-    // }
-    // // Fetch the data from the Github repo and cache it
-    // window.localStorage.setItem(LS_DATE_KEY, today);
     const ret = {};
     for (const key of dataSources.categoryKeys) {
         const resp = await fetch(dataSources[key]);
@@ -50,14 +17,6 @@ export async function fetchData() {
             throw new Error("Could not fetch data source from Github");
         }
         ret[key] = data;
-        // window.localStorage.setItem(LS_CACHE_PREFIX + key, data);
     }
     return ret;
-}
-
-function clearCache () {
-    window.localStorage.removeItem(LS_DATE_KEY);
-    for (const key of dataSources.categoryKeys) {
-        window.localStorage.removeItem(LS_CACHE_PREFIX + key);
-    }
 }


### PR DESCRIPTION
They recently stopped updating their previous data sources, and now they maintain new data sources that do not include recovered cases, so we have no way of calculating active cases. The dashboard is now a lot less useful. Pretty unfortunate, but what can you do :man_shrugging: 

This will at least provide motivation to add a new and better data source ASAP